### PR TITLE
typo fix ListContainerTest.cs changed items to item

### DIFF
--- a/Content.Tests/Client/UserInterface/Controls/ListContainerTest.cs
+++ b/Content.Tests/Client/UserInterface/Controls/ListContainerTest.cs
@@ -80,7 +80,7 @@ public sealed class ListContainerTest : RobustUnitTest
     {
         /*
          * 6 items * 10 height + 5 separation * 3 height = 75
-         * One items should be off the render
+         * One item should be off the render
          * 0 13 26 39 52 65 | 75 height
          */
         var root = new Control { MinSize = new Vector2(50, 60) };


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
typo fix, changed items to item.

## Why / Balance
changed it because i hate typos

## Technical details

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**
